### PR TITLE
Show help text when no arguments given, rather than an internal error

### DIFF
--- a/bin/git-notary
+++ b/bin/git-notary
@@ -242,4 +242,4 @@ notary() {
     esac
 }
 
-notary ${@}
+notary "${@:-}"


### PR DESCRIPTION
Previously:
```
$ git-notary
…/git-notary: 206: shift: can't shift that many
```

Now:
```
$ git-notary
git-notary 2.1.3
usage: 
       git-notary new <major|minor|patch> [object] [namespace]
       git-notary undo [object] [namespace]
       git-notary delta [--squash] [object] [base] [namespace]

       git-notary fetch [remote] [namespace]
       git-notary push [remote] [namespace]

       git-notary notes [branch] [base] [namespace]
       git-notary versions [initial]
       git-notary tags [--apply]
```

… Should I bump the version in this commit, or separately?