### PR TITLE
git-notary: Add `git-notary fetch --force` to clear local notes

### DIFF
--- a/bin/git-notary
+++ b/bin/git-notary
@@ -119,10 +119,15 @@ tags() {
 
 # fetch [remote] [namespace]
 fetch() {
+    FORCE=""
+    if test "${1:-}" = "--force"; then
+        shift
+        FORCE="+"
+    fi
     REMOTE=${1:-'origin'}
     NAMESPACE=${2:-${GIT_NOTARY_NAMESPACE}}
 
-    git fetch ${REMOTE} refs/notes/${NAMESPACE}:refs/notes/${NAMESPACE}
+    git fetch ${REMOTE} ${FORCE}refs/notes/${NAMESPACE}:refs/notes/${NAMESPACE}
 }
 
 # push [remote] [namespace]


### PR DESCRIPTION
This makes it easier to discard local changes (when you fetch after editing on top of a stale tree).